### PR TITLE
Add support for custom Verrazzano profile

### DIFF
--- a/oke.tf
+++ b/oke.tf
@@ -42,8 +42,11 @@ module "oke" {
   services_cidr               = var.services_cidr
 
   # node pools
-  node_pools = var.node_pools
   node_pool_name_prefix = var.node_pool_name_prefix
+
+  node_pools = {
+    np1 = { shape = "VM.Standard.E4.Flex", ocpus = 2, memory = 32, node_pool_size = 2, boot_volume_size = 150, label = { app = "frontend", pool = "np1" } }
+  }
 
   # oke load balancers
   load_balancers          = var.load_balancers

--- a/resources/oci_secret.template.yaml
+++ b/resources/oci_secret.template.yaml
@@ -1,0 +1,22 @@
+auth:
+  region: <your region eg. eu-frankfurt-1>
+  tenancy: <ocid1.tenancy.oc1.. imlhru7rdi5qb6qlnmrtgu3a>
+  user: <ocid1.user.oc1.. gvzhsvz37vgljmrbt5a>
+  key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEogIBAAKCAQEAmkGpG9VdFUAyDmOLdbHryAeJZdi8tkVfRLb8LaHjttgoF7o2
+    Aw/hn+jto6SndDeVVwDr6wxmCD3CaZNUnSqNJHnNrfSJe7dBaxFLc6KCQGQEfVFf
+    2H2eT6WMe8nfwkY1FH0lCPjtrTT3Zyu6RvxhtQMyNseBVbb9DNuHApex2BbtCfWH
+    FeV8E8OgQHbw/hj6CYhmySVCrsHS/1UahDQLiorScOb2jo7/K7dYQAZYFhaLchdS
+    tf6J9+hCw/5TcHD5JD78anACa5k2nPZbu2puvbi9jW+aVYsVkYoNCE5I+cu3BVxp
+    .
+    .
+    .
+    eOst/0Q/zhgBb4KLbrzGCZFBaia6Ja4Bq3sxhIglnUxhd7f0CZSv/0NMQOUJnkbQ
+    eV6FurfVMU6Ci1V1wpj5T0WeBOLzyfo261V9dHkspgNxEz/qywWzwaU46Bciw/dF
+    OZfZAoGAUyo5Aip5V3tuKDwJv15ZZ89ULdBe+AtoT+eICDtVI9zdZQDhCRKOFaJv
+    XxWYcV7d3MvihxaVhPaKis2+8FDHQtI6ibdqoPj9UNfXffs4o3/oopXJTkkVR2d8
+    eH8akxhRUTKoC3otd+X8BxDMc8iYt9+vjMmJtHxdYmS72bwDFCg=
+    -----END RSA PRIVATE KEY-----
+  fingerprint: 83:f5:72:3 ... :49:9c:53:29:e4:a6
+

--- a/resources/verrazzano.template.yaml
+++ b/resources/verrazzano.template.yaml
@@ -1,6 +1,29 @@
-  apiVersion: install.verrazzano.io/v1alpha1
-  kind: Verrazzano
-  metadata:
-    name: example-verrazzano
-  spec:
-    profile: dev
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+# This install resource installs the "prod" profile to install a full set of Verrazzano services
+# for production scenarios, using OCI DNS for name resolution of Verrazzano endpoints.
+#
+# Note that before you install verrazzano you need to run the create_oci_config_secret.sh in the
+# verrazzano/platform-operator/scripts/install directory to set up the ociConfigSecret below.
+#
+apiVersion: install.verrazzano.io/v1alpha1
+kind: Verrazzano
+metadata:
+  name: example-verrazzano
+spec:
+  environmentName: example-verrazzano
+  profile: dev
+  components:
+    certManager:
+      certificate:
+        acme:
+          provider: letsEncrypt
+          environment: staging
+          emailAddress: <your email>
+    dns:
+      oci:
+        ociConfigSecret: oci
+        dnsZoneCompartmentOCID: <ocid1.compartment.oc1.. mvgiqdatqgq>
+        dnsZoneOCID: <ocid1.dns-zone.oc1.. hjqqd3ug6nuazxnrsopiruq>
+        dnsZoneName: <your OCI DNS zone name>

--- a/scripts/install_verrazzano.template.sh
+++ b/scripts/install_verrazzano.template.sh
@@ -22,4 +22,6 @@ fi
 
 sed -i -e "s?example-verrazzano?${verrazzano_name}?g" verrazzano.yaml
 
+kubectl create secret -n verrazzano-install generic oci --from-file=oci_secret.yaml
+
 kubectl apply -f verrazzano.yaml

--- a/templates.tf
+++ b/templates.tf
@@ -19,4 +19,5 @@ locals {
 
   verrazzano_profile_template = templatefile("${path.module}/resources/verrazzano.template.yaml",{})
 
+  oci_secret_template = templatefile("${path.module}/resources/oci_secret.template.yaml",{})
 }

--- a/verrazzano.tf
+++ b/verrazzano.tf
@@ -31,6 +31,11 @@ resource "null_resource" "install_verrazzano" {
     destination = "~/verrazzano.yaml"
   }
 
+  provisioner "file" {
+    content     = local.oci_secret_template
+    destination = "~/oci_secret.yaml"
+  }
+
   provisioner "remote-exec" {
     inline = [
       "chmod +x $HOME/install_verrazzano_operator",


### PR DESCRIPTION
This issue is to show how to install Verrazzano using OCI DNS with Let's Encrypt.

It uses OCI DNS zone that needs to be created from the console.